### PR TITLE
update, if fs.Files == 0,set ret.InodesUsedPercent to 0; if fs.Blocks…

### DIFF
--- a/dfstat_linux.go
+++ b/dfstat_linux.go
@@ -95,22 +95,24 @@ func BuildDeviceUsage(_fsSpec, _fsFile, _fsVfstype string) (*DeviceUsage, error)
 	ret.BlocksUsed = uint64(fs.Frsize) * used
 	ret.BlocksFree = uint64(fs.Frsize) * fs.Bavail
 	if fs.Blocks == 0 {
-		ret.BlocksUsedPercent = 100.0
+		ret.BlocksUsedPercent = 0
+		ret.BlocksFreePercent = 0
 	} else {
 		ret.BlocksUsedPercent = float64(used) * 100.0 / float64(used+fs.Bavail)
+		ret.BlocksFreePercent = 100.0 - ret.BlocksUsedPercent
 	}
-	ret.BlocksFreePercent = 100.0 - ret.BlocksUsedPercent
 
 	// inodes
 	ret.InodesAll = fs.Files
 	ret.InodesFree = fs.Ffree
 	ret.InodesUsed = fs.Files - fs.Ffree
 	if fs.Files == 0 {
-		ret.InodesUsedPercent = 100.0
+		ret.InodesUsedPercent = 0
+		ret.InodesFreePercent = 0
 	} else {
 		ret.InodesUsedPercent = float64(ret.InodesUsed) * 100.0 / float64(ret.InodesAll)
+		ret.InodesFreePercent = 100.0 - ret.InodesUsedPercent
 	}
-	ret.InodesFreePercent = 100.0 - ret.InodesUsedPercent
 
 	return ret, nil
 }


### PR DESCRIPTION
update, if fs.Files == 0,set ret.InodesUsedPercent to 0; if fs.Blocks…
对于 fs.Files == 0将 ret.InodesUsedPercent 设置为100%有疑问，个人认为，设置为0更加妥当，这样不会产生因为100%而带来的不必要的报警以及困惑。
