### PR TITLE
修复由ops-updater启动falcon-agent时出现ss 命令无法执行的问题

### DIFF
--- a/portstat.go
+++ b/portstat.go
@@ -13,11 +13,11 @@ import (
 )
 
 func ListeningPorts() ([]int64, error) {
-	return listeningPorts("ss", "-t", "-l", "-n")
+	return listeningPorts("sh", "-c", "ss", "-t", "-l", "-n")
 }
 
 func UdpPorts() ([]int64, error) {
-	return listeningPorts("ss", "-u", "-a", "-n")
+	return listeningPorts("sh", "-c", "ss", "-u", "-a", "-n")
 }
 
 func listeningPorts(name string, args ...string) ([]int64, error) {

--- a/ss_s.go
+++ b/ss_s.go
@@ -12,7 +12,7 @@ import (
 func SocketStatSummary() (m map[string]uint64, err error) {
 	m = make(map[string]uint64)
 	var bs []byte
-	bs, err = sys.CmdOutBytes("ss", "-s")
+	bs, err = sys.CmdOutBytes("sh", "-c", "ss", "-s")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
我用ops-updater自动部署falcon-agent
但是启动以后监控的时候会经常出现这个错误
2016/08/23 21:45:44 sockstat.go:12: exec: "ss": executable file not found in $PATH
