### PR TITLE
Fix syntax error in command "sh -c"

### DIFF
--- a/portstat.go
+++ b/portstat.go
@@ -13,11 +13,11 @@ import (
 )
 
 func ListeningPorts() ([]int64, error) {
-	return listeningPorts("sh", "-c", "ss", "-t", "-l", "-n")
+	return listeningPorts("sh", "-c", "ss -t -l -n")
 }
 
 func UdpPorts() ([]int64, error) {
-	return listeningPorts("sh", "-c", "ss", "-u", "-a", "-n")
+	return listeningPorts("sh", "-c", "ss -u -a -n")
 }
 
 func listeningPorts(name string, args ...string) ([]int64, error) {

--- a/ss_s.go
+++ b/ss_s.go
@@ -12,7 +12,7 @@ import (
 func SocketStatSummary() (m map[string]uint64, err error) {
 	m = make(map[string]uint64)
 	var bs []byte
-	bs, err = sys.CmdOutBytes("sh", "-c", "ss", "-s")
+	bs, err = sys.CmdOutBytes("sh", "-c", "ss -s")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
sh -c string

If the -c option is present, then commands are read from string.
