### PR TITLE
fix(dfstat): 支持tmpfs类型磁盘监控

### DIFF
--- a/dfstat.go
+++ b/dfstat.go
@@ -8,19 +8,18 @@ import (
 var FSSPEC_IGNORE = map[string]struct{}{
 	"none":  struct{}{},
 	"nodev": struct{}{},
-	"tmpfs": struct{}{},
 }
 
 var FSTYPE_IGNORE = map[string]struct{}{
 	"cgroup":     struct{}{},
 	"debugfs":    struct{}{},
+	"devpts":     struct{}{},
 	"devtmpfs":   struct{}{},
 	"rpc_pipefs": struct{}{},
 	"rootfs":     struct{}{},
 }
 
 var FSFILE_PREFIX_IGNORE = []string{
-	"/dev",
 	"/sys",
 	"/net",
 	"/misc",


### PR DESCRIPTION
目的是支持对/dev/shm的监控，/dev/shm的应用较为广泛便捷，有必要添加基础监控