### PR TITLE
fix: inode free在一些文件系统上计算错误

### DIFF
--- a/dfstat_linux.go
+++ b/dfstat_linux.go
@@ -3,11 +3,13 @@ package nux
 import (
 	"bufio"
 	"bytes"
-	"github.com/toolkits/file"
 	"io"
 	"io/ioutil"
+	"math"
 	"strings"
 	"syscall"
+
+	"github.com/toolkits/file"
 )
 
 // return: [][$fs_spec, $fs_file, $fs_vfstype]
@@ -104,8 +106,13 @@ func BuildDeviceUsage(_fsSpec, _fsFile, _fsVfstype string) (*DeviceUsage, error)
 
 	// inodes
 	ret.InodesAll = fs.Files
-	ret.InodesFree = fs.Ffree
-	ret.InodesUsed = fs.Files - fs.Ffree
+	if fs.Ffree == math.MaxUint64 {
+		ret.InodesFree = 0
+		ret.InodesUsed = 0
+	} else {
+		ret.InodesFree = fs.Ffree
+		ret.InodesUsed = fs.Files - fs.Ffree
+	}
 	if fs.Files == 0 {
 		ret.InodesUsedPercent = 0
 		ret.InodesFreePercent = 0


### PR DESCRIPTION
个别文件系统在特定的Linux内核版本不能识别
使用`df -i`, "IUsed", "IFree", "IUse%"均会显示"-"
syscall.Statfs的返回值Ffree会溢出 
[https://golang.org/pkg/syscall/#Statfs_t](https://golang.org/pkg/syscall/#Statfs_t)
