### PR TITLE
fix: 取消对nfs类型磁盘监控

### DIFF
--- a/dfstat.go
+++ b/dfstat.go
@@ -17,6 +17,7 @@ var FSTYPE_IGNORE = map[string]struct{}{
 	"devtmpfs":   struct{}{},
 	"rpc_pipefs": struct{}{},
 	"rootfs":     struct{}{},
+	"nfs4":       struct{}{},
 }
 
 var FSFILE_PREFIX_IGNORE = []string{


### PR DESCRIPTION
本地机器挂载一个nfs目录，如果远程nfs存储服务器挂掉，agent取磁盘使用信息的时候会卡在取nfs挂载目录使用信息这一步，造成agent始终无法上报磁盘使用信息，所以这里就把nfs类型的目录排除掉吧