### PR TITLE
修复内核版本低于2.6.33时取不到net.if.speed.bits值的问题

### DIFF
--- a/ifstat.go
+++ b/ifstat.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/toolkits/file"
 	"io"
 	"io/ioutil"
 	"strconv"
 	"strings"
+
+	"github.com/toolkits/file"
+	"github.com/toolkits/sys"
 )
 
 const (
@@ -143,9 +145,46 @@ func NetIfs(onlyPrefix []string) ([]*NetIf, error) {
 				netIf.OutPercent = float64(netIf.OutBytes*BITS_PER_BYTE) * 100.0 / float64(netIf.SpeedBits)
 			}
 		} else {
-			netIf.SpeedBits = int64(0)
-			netIf.InPercent = float64(0)
-			netIf.OutPercent = float64(0)
+			if content, err := sys.CmdOutBytes("ethtool", netIf.Iface); err == nil {
+				var speed int64
+				var speedStr string
+
+				contentReader := bufio.NewReader(bytes.NewBuffer(content))
+				for {
+					line, err := file.ReadLine(contentReader)
+
+					if err == io.EOF {
+						err = nil
+						break
+					}
+
+					if err != nil {
+						break
+					}
+
+					line = bytes.Trim(line, "\t")
+
+					if bytes.HasPrefix(line, []byte("Speed:")) && bytes.HasSuffix(line, []byte("Mb/s")) {
+						speedStr = string(line[7 : len(line)-4])
+						break
+					}
+				}
+
+				speed, err = strconv.ParseInt(strings.TrimSpace(speedStr), 10, 64)
+				if speedStr == "" || err != nil || speed == 0 {
+					netIf.SpeedBits = int64(0)
+					netIf.InPercent = float64(0)
+					netIf.OutPercent = float64(0)
+				} else {
+					netIf.SpeedBits = speed * MILLION_BIT
+					netIf.InPercent = float64(netIf.InBytes*BITS_PER_BYTE) * 100.0 / float64(netIf.SpeedBits)
+					netIf.OutPercent = float64(netIf.OutBytes*BITS_PER_BYTE) * 100.0 / float64(netIf.SpeedBits)
+				}
+			} else {
+				netIf.SpeedBits = int64(0)
+				netIf.InPercent = float64(0)
+				netIf.OutPercent = float64(0)
+			}
 		}
 
 		ret = append(ret, &netIf)


### PR DESCRIPTION
[pr 9](https://github.com/toolkits/nux/pull/9) 中实现了抓取网卡参数: `net.if.speed.bits，net.if.in.percent，net.if.out.percent`的功能，当内核版本低于`2.6.33`时是不存在`/sys/class/net/<nic>/speed`文件的，[doc in here](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-net), 此时无法获取到网卡的真实值

当内核版本低于`2.6.33`时， 可以使用`ethtool`命令来实现这个功能，已经在线上机器`CentOS 5.5 Kernel version 2.6.18`的环境中验证生效